### PR TITLE
Fix build with cuda 12

### DIFF
--- a/ripserplusplus/ripser++.cu
+++ b/ripserplusplus/ripser++.cu
@@ -88,6 +88,7 @@
 #include <thrust/scan.h>
 #include <thrust/execution_policy.h>
 #include <thrust/unique.h>
+#include <thrust/sort.h>
 #include <cuda_runtime.h>
 #ifdef CPUONLY_SPARSE_HASHMAP
 #include <sparsehash/sparse_hash_map>


### PR DESCRIPTION
Currently risper-plusplus doesn't build when using CUDA 12 with the following error:

```
/tmp/pip-install-l5w0o4j3/ripserplusplus_959579c0f6214b699b52aa23ea21e284/./ripserplusplus/ripser++.cu(2378): error: namespace "thrust" has no member "sort"
            thrust::sort(thrust::device, d_columns_to_reduce, d_columns_to_reduce+ max_num_edges, cmp_reverse);
                    ^
      
      /tmp/pip-install-l5w0o4j3/ripserplusplus_959579c0f6214b699b52aa23ea21e284/./ripserplusplus/ripser++.cu(2468): error: namespace "thrust" has no member "sort"
            thrust::sort(thrust::device, d_simplices, d_simplices+ *h_num_simplices, cmp_reverse);
                    ^
      
      /tmp/pip-install-l5w0o4j3/ripserplusplus_959579c0f6214b699b52aa23ea21e284/./ripserplusplus/ripser++.cu(2586): error: namespace "thrust" has no member "sort"
            thrust::sort(thrust::device, d_pivot_array, d_pivot_array+*h_num_columns_to_reduce, cmp_pivots);
                    ^
      
      /tmp/pip-install-l5w0o4j3/ripserplusplus_959579c0f6214b699b52aa23ea21e284/./ripserplusplus/ripser++.cu(2587): error: namespace "thrust" has no member "sort"
            thrust::sort(thrust::device, d_pivot_column_index_OR_nonapparent_cols, d_pivot_column_index_OR_nonapparent_cols+*h_num_nonapparent);
                    ^
      
      /tmp/pip-install-l5w0o4j3/ripserplusplus_959579c0f6214b699b52aa23ea21e284/./ripserplusplus/ripser++.cu(2639): error: namespace "thrust" has no member "sort"
            thrust::sort(thrust::device, d_cidx_diameter_pairs_sortedlist, d_cidx_diameter_pairs_sortedlist+*h_num_columns_to_reduce, cmp_cidx_diameter);
                    ^
      
      /tmp/pip-install-l5w0o4j3/ripserplusplus_959579c0f6214b699b52aa23ea21e284/./ripserplusplus/ripser++.cu(2670): error: namespace "thrust" has no member "sort"
            thrust::sort(thrust::device, d_pivot_array, d_pivot_array+*h_num_columns_to_reduce, cmp_pivots);
                    ^
      
      /tmp/pip-install-l5w0o4j3/ripserplusplus_959579c0f6214b699b52aa23ea21e284/./ripserplusplus/ripser++.cu(2671): error: namespace "thrust" has no member "sort"
            thrust::sort(thrust::device, d_pivot_column_index_OR_nonapparent_cols, d_pivot_column_index_OR_nonapparent_cols+*h_num_nonapparent);
                    ^
      
      /tmp/pip-install-l5w0o4j3/ripserplusplus_959579c0f6214b699b52aa23ea21e284/./ripserplusplus/ripser++.cu(2760): error: namespace "thrust" has no member "sort"
            thrust::sort(thrust::device, d_columns_to_reduce, d_columns_to_reduce+ max_num_simplices, cmp);
                    ^
      
      /tmp/pip-install-l5w0o4j3/ripserplusplus_959579c0f6214b699b52aa23ea21e284/./ripserplusplus/ripser++.cu(2800): error: namespace "thrust" has no member "sort"
            thrust::sort(thrust::device, d_simplices, d_simplices+*h_num_simplices, cmp);
```

This is due to the missing include I added in this pull request.